### PR TITLE
[LLM] ⚡ Improve thread-safety and performance in timing and builders

### DIFF
--- a/resolver/src/main/java/net/evendanan/bazel/mvn/impl/TargetsBuilders.java
+++ b/resolver/src/main/java/net/evendanan/bazel/mvn/impl/TargetsBuilders.java
@@ -206,7 +206,7 @@ public class TargetsBuilders {
         try (InputStream inputStream =
             new BufferedInputStream(downloader.apply(dependency).toURL().openStream())) {
           final MessageDigest digest = MessageDigest.getInstance("SHA-256");
-          final byte[] readBuffer = new byte[4096];
+          final byte[] readBuffer = new byte[16384];
 
           int bytesCount;
           while ((bytesCount = inputStream.read(readBuffer)) != -1) {

--- a/resolver/src/main/java/net/evendanan/timing/ProgressTimer.java
+++ b/resolver/src/main/java/net/evendanan/timing/ProgressTimer.java
@@ -13,7 +13,7 @@ public class ProgressTimer {
     this.timer.start(tasksCount);
   }
 
-  public void taskDone(String taskName) {
+  public synchronized void taskDone(String taskName) {
     final TimingData timingData = timer.taskDone();
     final String estimatedTimeLeft;
     if (timingData.doneTasks >= 3) {
@@ -32,7 +32,7 @@ public class ProgressTimer {
         taskName);
   }
 
-  public void finish() {
+  public synchronized void finish() {
     TimingData finish = timer.finish();
     report("Finished. %s", TaskTiming.humanReadableTime(finish.totalTime - finish.startTime));
   }

--- a/resolver/src/main/java/net/evendanan/timing/TaskTiming.java
+++ b/resolver/src/main/java/net/evendanan/timing/TaskTiming.java
@@ -1,13 +1,12 @@
 package net.evendanan.timing;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class TaskTiming {
 
   private long startTime;
-  private final AtomicInteger completedTasks = new AtomicInteger(0);
-  private final AtomicInteger totalTasks = new AtomicInteger(0);
+  private int completedTasks = 0;
+  private int totalTasks = 0;
 
   public static String humanReadableTime(long milliseconds) {
     final long secondsInMilli = 1000;
@@ -26,36 +25,36 @@ public class TaskTiming {
     return timeString;
   }
 
-  public TimingData start(final int totalTasksCount) {
+  public synchronized TimingData start(final int totalTasksCount) {
     startTime = getCurrentTime();
-    completedTasks.set(0);
-    totalTasks.set(totalTasksCount);
+    completedTasks = 0;
+    totalTasks = totalTasksCount;
     return generateTimingData();
   }
 
-  public TimingData updateTotalTasks(final int totalTasksCount) {
-    totalTasks.set(totalTasksCount);
+  public synchronized TimingData updateTotalTasks(final int totalTasksCount) {
+    totalTasks = totalTasksCount;
     return generateTimingData();
   }
 
-  public TimingData taskDone() {
-    completedTasks.incrementAndGet();
+  public synchronized TimingData taskDone() {
+    completedTasks++;
     return generateTimingData();
   }
 
-  public TimingData finish() {
+  public synchronized TimingData finish() {
     return generateTimingData();
   }
 
   private TimingData generateTimingData() {
     final long totalTime = getCurrentTime();
     final long duration = totalTime - startTime;
-    final int completed = completedTasks.get();
-    final int total = totalTasks.get();
-    final float ratioOfDone = completed / (float) total;
-    final long estimatedTimeLeft = (long) (duration / ratioOfDone) - duration;
+    final float ratioOfDone = (totalTasks == 0) ? 0 : completedTasks / (float) totalTasks;
+    final long estimatedTimeLeft =
+        (ratioOfDone == 0) ? 0 : (long) (duration / ratioOfDone) - duration;
 
-    return new TimingData(total, completed, startTime, totalTime, estimatedTimeLeft, ratioOfDone);
+    return new TimingData(
+        totalTasks, completedTasks, startTime, totalTime, estimatedTimeLeft, ratioOfDone);
   }
 
   @VisibleForTesting


### PR DESCRIPTION
This PR implements the remaining improvements from PR #96 that were missing in the current branch.

### Changes:
- **Performance**: Increased buffer size in `HttpTargetsBuilder` from 4KB to 16KB for SHA-256 calculations.
- **Thread-Safety**: Added `synchronized` to `ProgressTimer` and `TaskTiming` methods to ensure consistent snapshots of timing data when parallelized.
- **Robustness**: Added a division-by-zero check in `TaskTiming` to prevent `NaN`/`Infinity` issues in progress reporting.

Verified with unit tests, checkstyle, and integration examples. Note: pre-existing failure in android example was identified and is unrelated to these changes.